### PR TITLE
breaking change: some configuration fields are renamed

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2,13 +2,13 @@
 
 path | type | required | default | description
 --- | --- | --- | --- | ---
-.items | item | true | | 
+.rules | rule | true | | 
 
-## type: item
+## type: rule
 
 path | type | required | default | example | description
 --- | --- | --- | --- | --- | ---
-rule | bool expression | true | | `Resource.Type == "null_resource"` | If the result is `true`, the resource is proceeded by the item
+if | bool expression | true | | `Resource.Type == "null_resource"` | If the result is `true`, the resource is proceeded by the item
 address | template | false | no change | `{{.Resource.Type}}.{{.Resource.Name \| replace "-" "_"}}` |
 dirname | template | false | no change | `foo` |
 hcl_file_basename | template | false | no change | `{{.Resource.Type}}.tf` |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -8,12 +8,13 @@ path | type | required | default | description
 
 path | type | required | default | example | description
 --- | --- | --- | --- | --- | ---
-if | bool expression | true | | `Resource.Type == "null_resource"` | If the result is `true`, the resource is proceeded by the item
+if | bool expression | true | | `Resource.Type == "null_resource"` | If the result is `true`, the resource is proceeded by the rule
 address | template | false | no change | `{{.Resource.Type}}.{{.Resource.Name \| replace "-" "_"}}` |
 dirname | template | false | no change | `foo` |
 hcl_file_basename | template | false | no change | `{{.Resource.Type}}.tf` |
 state_basename | template | false | terraform.tfstate | `foo.tfstate` |
-removed | bool | false | false | | If this is true, resources which match the item are removed 
+removed | bool | false | false | | If this is true, resources which match the rule are removed 
+ignored | bool | false | false | | If this is true, resources which match the rule aren't migrated by tfmigrator 
 skip_hcl_migration | bool | false | false | | If this is true, Terraform Configuration isn't changed
 skip_state_migration | bool | false | false | | If this is true, Terraform State isn't changed
 

--- a/examples/example1/tfmigrator.yaml
+++ b/examples/example1/tfmigrator.yaml
@@ -1,3 +1,3 @@
-items:
-- rule: Resource.Address == "null_resource.foo"
+rules:
+- if: Resource.Address == "null_resource.foo"
   address: null_resource.bar

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ type Rule struct {
 	Dirname            *text.Template
 	HCLFileBasename    *text.Template `yaml:"hcl_file_basename"`
 	StateBasename      *text.Template `yaml:"state_file_basename"`
+	Ignored            bool
 	Removed            bool
 	SkipHCLMigration   bool `yaml:"skip_hcl_migration"`
 	SkipStateMigration bool `yaml:"skip_state_migration"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,11 +10,11 @@ import (
 )
 
 type Config struct {
-	Items []*Item
+	Rules []*Rule
 }
 
-type Item struct {
-	Rule               *expr.Bool
+type Rule struct {
+	If                 *expr.Bool
 	Address            *text.Template
 	Dirname            *text.Template
 	HCLFileBasename    *text.Template `yaml:"hcl_file_basename"`

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -28,7 +28,7 @@ func (ctrl *Controller) Run(ctx context.Context, param *Param) error { //nolint:
 		return fmt.Errorf("read the configuration file %s: %w", param.ConfigFilePath, err)
 	}
 	pln := &planner.Planner{
-		Items: cfg.Items,
+		Rules: cfg.Rules,
 	}
 
 	logger := &tflog.SimpleLogger{}

--- a/pkg/planner/planner.go
+++ b/pkg/planner/planner.go
@@ -8,59 +8,59 @@ import (
 )
 
 type Planner struct {
-	Items []*config.Item
+	Rules []*config.Rule
 }
 
 func (planner *Planner) Plan(src *tfmigrator.Source) (*tfmigrator.MigratedResource, error) {
-	for _, item := range planner.Items {
-		matched, err := item.Rule.Run(src)
+	for _, rule := range planner.Rules {
+		matched, err := rule.If.Run(src)
 		if err != nil {
 			return nil, fmt.Errorf("evaluate the rule: %w", err)
 		}
 		if !matched {
 			continue
 		}
-		return planner.plan(src, item)
+		return planner.plan(src, rule)
 	}
 	return nil, nil
 }
 
-func (planner *Planner) plan(src *tfmigrator.Source, item *config.Item) (*tfmigrator.MigratedResource, error) {
+func (planner *Planner) plan(src *tfmigrator.Source, rule *config.Rule) (*tfmigrator.MigratedResource, error) {
 	rsc := &tfmigrator.MigratedResource{
-		Removed:            item.Removed,
-		SkipHCLMigration:   item.SkipHCLMigration,
-		SkipStateMigration: item.SkipStateMigration,
+		Removed:            rule.Removed,
+		SkipHCLMigration:   rule.SkipHCLMigration,
+		SkipStateMigration: rule.SkipStateMigration,
 	}
-	if item.Removed {
+	if rule.Removed {
 		return rsc, nil
 	}
 
-	if !item.Address.Empty() {
-		s, err := item.Address.Execute(src)
+	if !rule.Address.Empty() {
+		s, err := rule.Address.Execute(src)
 		if err != nil {
 			return nil, fmt.Errorf("evaluate the address: %w", err)
 		}
 		rsc.Address = s
 	}
 
-	if !item.Dirname.Empty() {
-		s, err := item.Dirname.Execute(src)
+	if !rule.Dirname.Empty() {
+		s, err := rule.Dirname.Execute(src)
 		if err != nil {
 			return nil, fmt.Errorf("evaluate the dirname: %w", err)
 		}
 		rsc.Dirname = s
 	}
 
-	if !item.HCLFileBasename.Empty() {
-		s, err := item.HCLFileBasename.Execute(src)
+	if !rule.HCLFileBasename.Empty() {
+		s, err := rule.HCLFileBasename.Execute(src)
 		if err != nil {
 			return nil, fmt.Errorf("evaluate the hcl_file_basename: %w", err)
 		}
 		rsc.HCLFileBasename = s
 	}
 
-	if !item.StateBasename.Empty() {
-		s, err := item.StateBasename.Execute(src)
+	if !rule.StateBasename.Empty() {
+		s, err := rule.StateBasename.Execute(src)
 		if err != nil {
 			return nil, fmt.Errorf("evaluate the state_basename: %w", err)
 		}

--- a/pkg/planner/planner.go
+++ b/pkg/planner/planner.go
@@ -20,6 +20,9 @@ func (planner *Planner) Plan(src *tfmigrator.Source) (*tfmigrator.MigratedResour
 		if !matched {
 			continue
 		}
+		if rule.Ignored {
+			return nil, nil
+		}
 		return planner.plan(src, rule)
 	}
 	return nil, nil


### PR DESCRIPTION
## Breaking Change

BREAKING CHNAGE: configuration fields are renamed

* Rename `items` to `rules`
* Rename `rule` to `if`

## Feature

Add `ignored` to `rule`

path | type | required | default | example | description
--- | --- | --- | --- | --- | ---
ignored | bool | false | false | | If this is true, resources which match the rule aren't migrated by tfmigrator